### PR TITLE
Add support for the new "missing" flag to show missing games.

### DIFF
--- a/layer_grid/GameGridItem.qml
+++ b/layer_grid/GameGridItem.qml
@@ -64,6 +64,16 @@ Item {
         onStatusChanged: if (status === Image.Ready) {
             root.imageLoaded(implicitWidth, implicitHeight);
         }
+
+        Rectangle {
+            anchors.centerIn: parent
+            visible: game.missing
+
+            color: "#808080"
+            width: boxFront.width
+            height: boxFront.height
+            opacity: 0.4
+        }
     }
 
     Image {
@@ -89,7 +99,7 @@ Item {
         text: game.title
         wrapMode: Text.Wrap
         horizontalAlignment: Text.AlignHCenter
-        color: "#eee"
+        color: game.missing ? "#808080" : "#eee"
         font {
             pixelSize: vpx(16)
             family: globalFonts.sans

--- a/theme.qml
+++ b/theme.qml
@@ -167,6 +167,8 @@ FocusScope {
     }
 
     function launchGame() {
+        if (gamegrid.currentGame.missing)
+            return;
         api.memory.set('collection', topbar.currentCollection.name);
         api.memory.set('game', gamegrid.currentGame.title);
         gamegrid.currentGame.launch();


### PR DESCRIPTION
Indicators/changes for missing games:
- Prevent Launching a missing game
- Grid view will add a grey overlay to fade it slightly
- If no grid image present, the title text on the grid will be grey instead of white